### PR TITLE
openDate and closingDate missing from d.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bastaai/basta-admin-js",
-  "version": "0.1.0-beta.118",
+  "version": "0.1.0-beta.119",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bastaai/basta-admin-js",
-      "version": "0.1.0-beta.118",
+      "version": "0.1.0-beta.119",
       "license": "UNLICENSED",
       "devDependencies": {
         "@graphql-codegen/cli": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastaai/basta-admin-js",
-  "version": "0.1.0-beta.118",
+  "version": "0.1.0-beta.119",
   "description": "Basta Admin SDK is a specialized toolkit, designed with the purpose of facilitating the management and execution of Basta auctions.",
   "author": "Basta (https://www.basta.ai)",
   "homepage": "https://docs.basta.ai",

--- a/types/item.d.ts
+++ b/types/item.d.ts
@@ -67,12 +67,24 @@ export type AddItemToSaleInput = {
   allowedBidTypes?: Array<BidType> | null | undefined;
   /** Optional bid increment table for this item. */
   bidIncrementTable?: BidIncrementTableInput | null | undefined;
+  /**
+   * Date and time when item should close.
+   * Format: RFC3339 timestamp.
+   * Example: "2019-10-12T07:20:50.52Z"
+   */
+  closingDate: string;
   /** High estimate of the item (optional) in minor currency unit. */
   highEstimate?: number | null | undefined;
   /** Item id of the item that you are adding to the sale. */
   itemId: string;
   /** Low estimate of the item (optional) in minor currency unit. */
   lowEstimate?: number | null | undefined;
+  /**
+   * Date and time when item should open up for bidding.
+   * Format: RFC3339 timestamp.
+   * Example: "2019-10-12T07:20:50.52Z"
+   */
+  openDate: string;
   /** Reserve of the item in minor currency unit. */
   reserve?: number | null | undefined;
   /** Id of the sale that is associated with the item. */


### PR DESCRIPTION
# What?
- `openDate` and `closingDate` missing from the `AddItemToSaleInput` type. This means that consumers of the sdk can't add these two required fields when calling the `item.addItemToSale` mutation.